### PR TITLE
home-manager: curry home modules over dotfiles' own inputs

### DIFF
--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -1,4 +1,5 @@
 # Full personal machine config — imports headless.nix, adds GUI/personal/hobby stuff.
+{ inputs }:
 {
   config,
   pkgs,
@@ -7,7 +8,7 @@
 }:
 
 {
-  imports = [ ./modules/headless.nix ];
+  imports = [ (import ./modules/headless.nix { inherit inputs; }) ];
 
   home.packages = with pkgs; [
     cmatrix

--- a/nix/home/modules/agent-skills.nix
+++ b/nix/home/modules/agent-skills.nix
@@ -5,10 +5,10 @@
 # structure (rsync -a --delete in home.activation). The module's default
 # exclude pattern (`/.system`) keeps Codex's `~/.codex/skills/.system` dir
 # from being deleted by the sync.
+{ inputs }:
 {
   config,
   lib,
-  inputs,
   ...
 }:
 
@@ -42,13 +42,15 @@ in
 
     sources = {
       # github:shadcn/improve -> skills/improve
+      # Resolved by store path from dotfiles' own pin so the consumer doesn't
+      # have to expose a `shadcn-improve` flake input via extraSpecialArgs.
       shadcn-improve = {
-        input = "shadcn-improve";
+        path = inputs.shadcn-improve.outPath;
         subdir = "skills";
       };
       # github:vercel-labs/skills -> skills/find-skills
       vercel-skills = {
-        input = "vercel-skills";
+        path = inputs.vercel-skills.outPath;
         subdir = "skills";
       };
     };

--- a/nix/home/modules/default.nix
+++ b/nix/home/modules/default.nix
@@ -1,6 +1,7 @@
+{ inputs }:
 {
   imports = [
-    ../common.nix
+    (import ../common.nix { inherit inputs; })
     ../os-specific/nixos/standard.nix
     ../os-specific/nixos/gui.nix
     ../os-specific/darwin.nix

--- a/nix/home/modules/headless.nix
+++ b/nix/home/modules/headless.nix
@@ -1,10 +1,14 @@
 # Headless home-manager module: cross-platform, no GUI, no personal identity.
 # Import this on any remote server for a batteries-included terminal environment.
+#
+# Curried over dotfiles' own flake `inputs` so claude-code-nix / codex-cli-nix
+# (and, via agent-skills.nix, the skill sources) resolve from dotfiles' pins
+# rather than from the consumer's extraSpecialArgs.
+{ inputs }:
 {
   config,
   pkgs,
   lib,
-  inputs,
   ...
 }:
 
@@ -16,7 +20,7 @@ in
   imports = [
     ../options.nix
     ../dotfiles.nix
-    ./agent-skills.nix
+    (import ./agent-skills.nix { inherit inputs; })
     ../../nix-settings-shared.nix
   ];
 

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -1,9 +1,14 @@
-{ ... }:
+{ inputs, ... }:
 {
   flake = {
     homeModules = {
-      default = import ../home/modules;
-      headless = import ../home/modules/headless.nix;
+      # Apply dotfiles' own flake inputs at eval time so the home modules close
+      # over agent-skills / claude-code-nix / codex-cli-nix / shadcn-improve /
+      # vercel-skills themselves. Consumers no longer need to mirror those into
+      # the `inputs` they pass via extraSpecialArgs (mirrors the nixos path,
+      # which already curries `{ inherit inputs; }`).
+      default = import ../home/modules { inherit inputs; };
+      headless = import ../home/modules/headless.nix { inherit inputs; };
     };
   };
 }


### PR DESCRIPTION
## Problem

The headless home-module chain referenced `agent-skills` / `claude-code-nix` / `codex-cli-nix` / `shadcn-improve` / `vercel-skills` by **bare name out of the home-manager module args** — i.e. the *consumer-supplied* `extraSpecialArgs.inputs`. `agent-skills-nix` likewise resolves `sources.*.input = "name"` by looking the name up in that same attrset.

The result: every external consumer of `homeModules.{default,headless}` had to mirror those five inputs into their own flake via `*.follows = "dotfiles/*"`, just to satisfy dotfiles' *private* dependencies.

The **nixos** path never had this problem — it curries `{ inherit inputs; }` at flake-eval time (`nix/nixos/modules/default.nix` is `{ inputs }:`). Only the home export shipped the modules unapplied.

## Fix

Mirror the nixos pattern for the home export: apply dotfiles' own flake inputs at eval time and thread them down.

- `nix/modules/home-manager.nix` — `default`/`headless` now `import … { inherit inputs; }`.
- `home/modules/default.nix`, `home/common.nix`, `home/modules/headless.nix`, `home/modules/agent-skills.nix` — curried `{ inputs }: <module>`, applying `{ inherit inputs; }` at each path-import.
- agent-skills sources switch from `input = "shadcn-improve"` (consumer lookup) to `path = inputs.shadcn-improve.outPath` (dotfiles' own pin). The `path` branch of `resolveSourceRoot` is preferred and bypasses the consumer `inputs` entirely.

Consumers no longer need to re-expose any of those inputs.

## Verification

- `nix build .#nixosConfigurations.ci-bare.config.home-manager.users.igm.programs.agent-skills.bundlePath` → bundle with `improve` + `find-skills` symlinks.
- Downstream `nixos-rebuild build .#devbox` (with `--override-input dotfiles git+file://…`) built clean; consuming flake dropped all five `follows` lines.
- `scripts/devbox-switch` activated; `~/.claude/skills/{improve,find-skills}` present, `home-manager-igm.service` = success.