### PR TITLE
flake: add host builders and consolidate partition wiring

### DIFF
--- a/nix/modules/darwin.nix
+++ b/nix/modules/darwin.nix
@@ -1,9 +1,5 @@
 { inputs, ... }:
 {
-  imports = [
-    inputs.flake-parts.flakeModules.partitions
-  ];
-
   partitionedAttrs = {
     darwinModules = "darwin";
     darwinConfigurations = "darwin";
@@ -12,73 +8,60 @@
   partitions.darwin = {
     extraInputsFlake = ../darwin;
     module =
-      { inputs, ... }:
+      { inputs, lib, ... }:
       let
         inherit (inputs) darwin dotfiles-private;
         darwinModule = import ../darwin/modules { inherit inputs; };
         privateModule = dotfiles-private.darwinModules.default;
+
+        mkDarwinHost =
+          {
+            system,
+            hostName,
+            computerName ? hostName,
+            localHostName ? hostName,
+            private ? true,
+          }:
+          darwin.lib.darwinSystem {
+            modules = [
+              darwinModule
+            ]
+            ++ lib.optional private privateModule
+            ++ [
+              {
+                nixpkgs.hostPlatform = system;
+                networking = {
+                  inherit computerName hostName localHostName;
+                };
+              }
+            ];
+          };
       in
       {
         flake = {
           darwinModules.default = darwinModule;
 
-          darwinConfigurations."ian-mbp-intel" = darwin.lib.darwinSystem {
-            modules = [
-              darwinModule
-              privateModule
-
-              {
-                nixpkgs.hostPlatform = "x86_64-darwin";
-                networking = {
-                  computerName = "Ian's Macbook Pro Intel";
-                  hostName = "ian-mbp-intel";
-                  localHostName = "ian-mbp-intel";
-                };
-              }
-            ];
-          };
-          darwinConfigurations."ian-mbp-2022" = darwin.lib.darwinSystem {
-            modules = [
-              darwinModule
-              privateModule
-
-              {
-                nixpkgs.hostPlatform = "aarch64-darwin";
-                networking = {
-                  computerName = "Ian MBP 2022";
-                  hostName = "ian-mbp-2022";
-                  localHostName = "ian-mbp-2022";
-                };
-              }
-            ];
-          };
-          darwinConfigurations.ci-personal = darwin.lib.darwinSystem {
-            modules = [
-              darwinModule
-
-              {
-                nixpkgs.hostPlatform = "x86_64-darwin";
-                networking = {
-                  computerName = "igm-darwin-ci";
-                  hostName = "igm-darwin-ci";
-                  localHostName = "igm-darwin-ci";
-                };
-              }
-            ];
-          };
-          darwinConfigurations.ci-personal-m1 = darwin.lib.darwinSystem {
-            modules = [
-              darwinModule
-
-              {
-                nixpkgs.hostPlatform = "aarch64-darwin";
-                networking = {
-                  computerName = "igm-darwin-ci-m1";
-                  hostName = "igm-darwin-ci-m1";
-                  localHostName = "igm-darwin-ci-m1";
-                };
-              }
-            ];
+          darwinConfigurations = {
+            "ian-mbp-intel" = mkDarwinHost {
+              system = "x86_64-darwin";
+              hostName = "ian-mbp-intel";
+              computerName = "Ian's Macbook Pro Intel";
+            };
+            "ian-mbp-2022" = mkDarwinHost {
+              system = "aarch64-darwin";
+              hostName = "ian-mbp-2022";
+              computerName = "Ian MBP 2022";
+            };
+            ci-personal = mkDarwinHost {
+              system = "x86_64-darwin";
+              hostName = "igm-darwin-ci";
+              private = false;
+            };
+            ci-personal-m1 = mkDarwinHost {
+              system = "aarch64-darwin";
+              hostName = "igm-darwin-ci-m1";
+              private = false;
+            };
           };
         };
       };

--- a/nix/modules/dev-partition.nix
+++ b/nix/modules/dev-partition.nix
@@ -1,0 +1,69 @@
+{ ... }:
+{
+  partitions.dev = {
+    extraInputsFlake = ../dev;
+    module =
+      { inputs, ... }:
+      {
+        imports = [
+          inputs.git-hooks-nix.flakeModule
+          inputs.treefmt-nix.flakeModule
+          ./dev-shells.nix
+        ];
+
+        perSystem =
+          {
+            config,
+            pkgs,
+            system,
+            ...
+          }:
+          {
+            _module.args.pkgs = import inputs.nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+            };
+
+            treefmt = {
+              programs.nixfmt.enable = true;
+              programs.shfmt = {
+                enable = true;
+                indent_size = 2;
+              };
+              programs.stylua.enable = true;
+              programs.kdlfmt.enable = true;
+              programs.dprint = {
+                enable = true;
+                includes = [
+                  "*.md"
+                  "*.json"
+                  "*.yml"
+                  "*.yaml"
+                  "*.html"
+                ];
+                settings.plugins = pkgs.dprint-plugins.getPluginList (
+                  plugins: with plugins; [
+                    dprint-plugin-json
+                    dprint-plugin-markdown
+                    g-plane-pretty_yaml
+                    g-plane-markup_fmt
+                  ]
+                );
+              };
+            };
+
+            pre-commit.check.enable = false;
+            pre-commit.settings.hooks.treefmt.enable = true;
+
+            devShells.default = pkgs.mkShell {
+              shellHook = config.pre-commit.installationScript;
+              packages = with pkgs; [
+                git
+                coreutils-full
+                dprint
+              ];
+            };
+          };
+      };
+  };
+}

--- a/nix/modules/nixos.nix
+++ b/nix/modules/nixos.nix
@@ -1,9 +1,5 @@
 { inputs, ... }:
 {
-  imports = [
-    inputs.flake-parts.flakeModules.partitions
-  ];
-
   partitionedAttrs = {
     nixosModules = "nixos";
     nixosConfigurations = "nixos";
@@ -16,52 +12,53 @@
       let
         inherit (inputs) nixpkgs;
         nixosModule = import ../nixos/modules { inherit inputs; };
+        headlessModule = import ../nixos/modules/headless.nix { inherit inputs; };
+
+        mkNixosHost =
+          {
+            system ? "x86_64-linux",
+            modules ? [ ],
+          }:
+          nixpkgs.lib.nixosSystem {
+            modules = [
+              ../nixos/machines/ci.nix
+              { nixpkgs.hostPlatform = system; }
+            ]
+            ++ modules;
+          };
       in
       {
         flake = {
           nixosModules.default = nixosModule;
-          nixosModules.headless = import ../nixos/modules/headless.nix { inherit inputs; };
+          nixosModules.headless = headlessModule;
 
-          nixosConfigurations.ci-headless = nixpkgs.lib.nixosSystem {
-            modules = [
-              (import ../nixos/modules/headless.nix { inherit inputs; })
-              ../nixos/machines/ci.nix
-              {
-                nixpkgs.hostPlatform = "x86_64-linux";
-                system.stateVersion = "24.05";
-              }
-            ];
-          };
-
-          nixosConfigurations.ci-home = nixpkgs.lib.nixosSystem {
-            modules = [
-              nixosModule
-              ../nixos/machines/ci.nix
-              { nixpkgs.hostPlatform = "x86_64-linux"; }
-            ];
-          };
-          nixosConfigurations.ci-bare = nixpkgs.lib.nixosSystem {
-            modules = [
-              nixosModule
-              ../nixos/machines/ci.nix
-              {
-                nixpkgs.hostPlatform = "x86_64-linux";
-                igm.headless = true;
-              }
-            ];
-          };
-          nixosConfigurations.vbox-host = nixpkgs.lib.nixosSystem {
-            modules = [
-              nixosModule
-              ../nixos/machines/ci.nix
-              {
-                nixpkgs.hostPlatform = "x86_64-linux";
-                igm = {
-                  headless = true;
-                  virtualbox = true;
-                };
-              }
-            ];
+          nixosConfigurations = {
+            ci-headless = mkNixosHost {
+              modules = [
+                headlessModule
+                { system.stateVersion = "24.05"; }
+              ];
+            };
+            ci-home = mkNixosHost {
+              modules = [ nixosModule ];
+            };
+            ci-bare = mkNixosHost {
+              modules = [
+                nixosModule
+                { igm.headless = true; }
+              ];
+            };
+            vbox-host = mkNixosHost {
+              modules = [
+                nixosModule
+                {
+                  igm = {
+                    headless = true;
+                    virtualbox = true;
+                  };
+                }
+              ];
+            };
           };
         };
       };

--- a/nix/modules/partitions.nix
+++ b/nix/modules/partitions.nix
@@ -2,78 +2,12 @@
 {
   imports = [
     inputs.flake-parts.flakeModules.partitions
+    ./dev-partition.nix
   ];
 
   partitionedAttrs = {
     checks = "dev";
     devShells = "dev";
     formatter = "dev";
-  };
-
-  partitions.dev = {
-    extraInputsFlake = ../dev;
-    module =
-      { inputs, ... }:
-      {
-        imports = [
-          inputs.git-hooks-nix.flakeModule
-          inputs.treefmt-nix.flakeModule
-          ./dev-shells.nix
-        ];
-
-        perSystem =
-          {
-            config,
-            pkgs,
-            system,
-            ...
-          }:
-          {
-            _module.args.pkgs = import inputs.nixpkgs {
-              inherit system;
-              config.allowUnfree = true;
-            };
-
-            treefmt = {
-              programs.nixfmt.enable = true;
-              programs.shfmt = {
-                enable = true;
-                indent_size = 2;
-              };
-              programs.stylua.enable = true;
-              programs.kdlfmt.enable = true;
-              programs.dprint = {
-                enable = true;
-                includes = [
-                  "*.md"
-                  "*.json"
-                  "*.yml"
-                  "*.yaml"
-                  "*.html"
-                ];
-                settings.plugins = pkgs.dprint-plugins.getPluginList (
-                  plugins: with plugins; [
-                    dprint-plugin-json
-                    dprint-plugin-markdown
-                    g-plane-pretty_yaml
-                    g-plane-markup_fmt
-                  ]
-                );
-              };
-            };
-
-            pre-commit.check.enable = false;
-            pre-commit.settings.hooks.treefmt.enable = true;
-
-            devShells.default = pkgs.mkShell {
-              shellHook = config.pre-commit.installationScript;
-              packages = with pkgs; [
-                git
-                coreutils-full
-                dprint
-              ];
-            };
-          };
-      };
   };
 }


### PR DESCRIPTION
Pure flake-parts refactor — no behavioral change to any built system.

## What
- **`mkDarwinHost` / `mkNixosHost` builders** replace the repeated `darwinSystem`/`nixosSystem` boilerplate. Adding a machine is now a few declarative lines.
- **Partitions flakeModule imported once** (in `partitions.nix`) instead of in three separate files.
- **Dev partition split out** into `nix/modules/dev-partition.nix`; `partitions.nix` is now pure wiring.
- The nixos `headless` module is bound once instead of imported twice.

## Verification
All `darwinConfigurations` / `nixosConfigurations` evaluate to identical values, and `devShells` attrnames match baseline. `nix fmt` clean.

- `nix eval --json --apply builtins.attrNames .#nixosConfigurations` → `["ci-bare","ci-headless","ci-home","vbox-host"]`
- `nix eval --json --apply builtins.attrNames .#darwinConfigurations` → `["ci-personal","ci-personal-m1","ian-mbp-2022","ian-mbp-intel"]`
- per-host `networking.*`, `igm.headless`, `system.stateVersion`, `igm.virtualbox` all unchanged.