### PR TITLE
nixpkgs: unify nixpkgs config and remove dead code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,5 @@
         ./nix/modules/darwin.nix
         ./nix/modules/home-manager.nix
       ];
-
-      flake = { };
     };
 }

--- a/nix/darwin/modules/default.nix
+++ b/nix/darwin/modules/default.nix
@@ -28,10 +28,8 @@ in
   igm.mode = "personal";
 
   nixpkgs = import ../../nixpkgs/config.nix {
+    inherit self;
     isDarwin = true;
-    additionalOverlays = [
-      self.overlays.default
-    ];
   };
 
   environment.systemPackages =

--- a/nix/nixos/modules/default.nix
+++ b/nix/nixos/modules/default.nix
@@ -48,6 +48,6 @@ in
   ];
 
   nixpkgs = import ../../nixpkgs/config.nix {
-    additionalOverlays = [ self.overlays.default ];
+    inherit self;
   };
 }

--- a/nix/nixos/modules/headless.nix
+++ b/nix/nixos/modules/headless.nix
@@ -23,13 +23,16 @@
     ];
   };
 
-  nixpkgs.overlays = [ inputs.self.overlays.default ];
-  nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (pkg.pname or "") [
-      "claude-code"
-      "codex"
-    ];
+  nixpkgs = import ../../nixpkgs/config.nix {
+    self = inputs.self;
+    pulseaudio = false;
+    allowUnfreePredicate =
+      pkg:
+      builtins.elem (pkg.pname or "") [
+        "claude-code"
+        "codex"
+      ];
+  };
 
   programs.zsh.enable = true;
   programs.nix-ld.enable = true;

--- a/nix/nixpkgs/config.nix
+++ b/nix/nixpkgs/config.nix
@@ -1,12 +1,17 @@
 {
-  additionalOverlays ? [ ],
+  self,
   isDarwin ? false,
+  pulseaudio ? !isDarwin,
+  allowUnfree ? true,
+  allowUnfreePredicate ? null,
 }:
 {
   config = {
-    allowUnfree = true;
-    pulseaudio = !isDarwin;
-  };
+    inherit pulseaudio;
+  }
+  // (
+    if allowUnfreePredicate != null then { inherit allowUnfreePredicate; } else { inherit allowUnfree; }
+  );
 
-  overlays = additionalOverlays;
+  overlays = [ self.overlays.default ];
 }

--- a/nix/nixpkgs/default.nix
+++ b/nix/nixpkgs/default.nix
@@ -1,3 +1,0 @@
-{ }:
-
-import <nixpkgs> (import ./config.nix)


### PR DESCRIPTION
Pure refactor — every config's evaluated nixpkgs settings match baseline.

## What
- **Unify the three nixpkgs config call sites** (full nixos, darwin, headless) through one parameterized `nix/nixpkgs/config.nix`, replacing two import sites plus a hand-inlined headless block. Each profile's distinct settings are preserved (full: `allowUnfree`+pulseaudio; darwin: `allowUnfree`, no pulseaudio; headless: `allowUnfreePredicate` for claude-code/codex only).
- **Remove dead code**: unused `nix/nixpkgs/default.nix` (`import <nixpkgs>`, unreferenced) and the empty `flake = { };` attribute in `flake.nix`.

## Verification (baseline vs branch, all match)
- `ci-home`: `allowUnfree=true`, `pulseaudio=true`, overlays length `1`
- `ci-headless`: no `allowUnfree` key, `allowUnfreePredicate` is a function, overlays length `1`
- `darwin ci-personal`: `allowUnfree=true`, `pulseaudio=false`

One intentional, behavior-neutral difference: headless's `nixpkgs.config` now carries an explicit `pulseaudio = false` (nixpkgs defaults this to false when absent, so no package builds differently).