### PR TITLE
agent-skills: add blader/humanizer skill

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -381,6 +381,22 @@
         "type": "github"
       }
     },
+    "humanizer": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780874875,
+        "narHash": "sha256-ub6w8mgYHnN7IXPJHgPiuH3mi3r6O0DNccCqAzP0Xi8=",
+        "owner": "blader",
+        "repo": "humanizer",
+        "rev": "9600f2b7241cb4eed6ad803abee5ea01d67fe8e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "blader",
+        "repo": "humanizer",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780365719,
@@ -510,6 +526,7 @@
         "dotfiles-private": "dotfiles-private",
         "flake-parts": "flake-parts_2",
         "home-manager": "home-manager",
+        "humanizer": "humanizer",
         "nixpkgs": "nixpkgs_5",
         "shadcn-improve": "shadcn-improve",
         "vercel-skills": "vercel-skills",

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,10 @@
       url = "github:vercel-labs/skills";
       flake = false;
     };
+    humanizer = {
+      url = "github:blader/humanizer";
+      flake = false;
+    };
     zjstatus = {
       url = "github:dj95/zjstatus";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/home/modules/agent-skills.nix
+++ b/nix/home/modules/agent-skills.nix
@@ -53,11 +53,17 @@ in
         path = inputs.vercel-skills.outPath;
         subdir = "skills";
       };
+      # github:blader/humanizer -> SKILL.md lives at the repo root (no subdir),
+      # so the discovered skill id is the source name `humanizer`.
+      humanizer = {
+        path = inputs.humanizer.outPath;
+      };
     };
 
     skills.enable = [
       "improve"
       "find-skills"
+      "humanizer"
     ];
 
     targets = {


### PR DESCRIPTION
Adds the [blader/humanizer](https://github.com/blader/humanizer) Claude Code skill to the declarative `agent-skills-nix` setup.

## Changes
- Add `humanizer` as a `flake = false` input pinned to `github:blader/humanizer`.
- Register it as a source in `nix/home/modules/agent-skills.nix`. Its `SKILL.md` lives at the repo root (no `skills/` subdir), so `subdir` is left at the default `.` and the discovered skill id is the source name `humanizer`.
- Enable the `humanizer` skill, so it syncs into every Claude/Codex skills target alongside `improve` and `find-skills`.

## Verification
- `nix flake lock` adds the `humanizer` input.
- `nix eval .#nixosConfigurations.ci-headless.config.system.build.toplevel.drvPath` evaluates cleanly, confirming the skill id is discovered and selected (the module throws at eval time on a missing/mismatched skill id).
- `nix fmt` reports no formatting changes.