### PR TITLE
home: add kepano/obsidian-skills agent skills

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,6 +492,22 @@
         "type": "github"
       }
     },
+    "obsidian-skills": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780935121,
+        "narHash": "sha256-/Kr3cMaN81WXFxgWMNt/QQhEMzuu3e3WJpspqjrnPss=",
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "rev": "a1dc48e68138490d522c04cbf5822214c6eb1202",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kepano",
+        "repo": "obsidian-skills",
+        "type": "github"
+      }
+    },
     "ragenix": {
       "inputs": {
         "agenix": "agenix",
@@ -528,6 +544,7 @@
         "home-manager": "home-manager",
         "humanizer": "humanizer",
         "nixpkgs": "nixpkgs_5",
+        "obsidian-skills": "obsidian-skills",
         "shadcn-improve": "shadcn-improve",
         "vercel-skills": "vercel-skills",
         "zjstatus": "zjstatus"

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,10 @@
       url = "github:vercel-labs/skills";
       flake = false;
     };
+    obsidian-skills = {
+      url = "github:kepano/obsidian-skills";
+      flake = false;
+    };
     humanizer = {
       url = "github:blader/humanizer";
       flake = false;

--- a/nix/home/modules/agent-skills.nix
+++ b/nix/home/modules/agent-skills.nix
@@ -53,6 +53,11 @@ in
         path = inputs.vercel-skills.outPath;
         subdir = "skills";
       };
+      # github:kepano/obsidian-skills -> skills/{defuddle,json-canvas,obsidian-bases,obsidian-cli,obsidian-markdown}
+      obsidian-skills = {
+        path = inputs.obsidian-skills.outPath;
+        subdir = "skills";
+      };
       # github:blader/humanizer -> SKILL.md lives at the repo root (no subdir),
       # so the discovered skill id is the source name `humanizer`.
       humanizer = {
@@ -63,6 +68,11 @@ in
     skills.enable = [
       "improve"
       "find-skills"
+      "defuddle"
+      "json-canvas"
+      "obsidian-bases"
+      "obsidian-cli"
+      "obsidian-markdown"
       "humanizer"
     ];
 


### PR DESCRIPTION
Adds github:kepano/obsidian-skills (MIT) as a flake=false input and wires it into programs.agent-skills, exactly mirroring the existing shadcn-improve / vercel-skills setup.

Enables five Obsidian skills, synced into the Claude Code + Codex skills dirs via the existing symlink-tree targets:
- defuddle
- json-canvas
- obsidian-bases
- obsidian-cli
- obsidian-markdown

## Verification
- `nix flake lock` adds the obsidian-skills node.
- `nix eval .#nixosConfigurations.ci-home.config.home-manager.users.igm.home.activationPackage.drvPath` evaluates cleanly (full home config, all skill names resolve).
- `nix fmt` clean.