### PR TITLE
dev: migrate formatting from prettier/dprint to oxfmt

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["arcanis.vscode-zipfs", "esbenp.prettier-vscode"]
+  "recommendations": ["arcanis.vscode-zipfs", "oxc.oxc-vscode"]
 }

--- a/config/cursor/settings.json
+++ b/config/cursor/settings.json
@@ -37,14 +37,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "files.associations": {
     "*.md": "markdown",
     "*.toml": "toml",

--- a/config/vscode/settings.json
+++ b/config/vscode/settings.json
@@ -33,14 +33,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "files.associations": {
     "*.md": "markdown",
     "*.toml": "toml",

--- a/nix/modules/dev-partition.nix
+++ b/nix/modules/dev-partition.nix
@@ -32,24 +32,10 @@
               };
               programs.stylua.enable = true;
               programs.kdlfmt.enable = true;
-              programs.dprint = {
-                enable = true;
-                includes = [
-                  "*.md"
-                  "*.json"
-                  "*.yml"
-                  "*.yaml"
-                  "*.html"
-                ];
-                settings.plugins = pkgs.dprint-plugins.getPluginList (
-                  plugins: with plugins; [
-                    dprint-plugin-json
-                    dprint-plugin-markdown
-                    g-plane-pretty_yaml
-                    g-plane-markup_fmt
-                  ]
-                );
-              };
+              # Oxc formatter (oxfmt) handles the full web/data set via its
+              # default includes: JS/TS/JSX/TSX, JSON/JSONC/JSON5, CSS/SCSS,
+              # HTML, Markdown/MDX, YAML, GraphQL, Vue. Replaces dprint entirely.
+              programs.oxfmt.enable = true;
             };
 
             pre-commit.check.enable = false;
@@ -60,7 +46,6 @@
               packages = with pkgs; [
                 git
                 coreutils-full
-                dprint
               ];
             };
           };


### PR DESCRIPTION
Consolidates all non-Nix/shell/lua formatting onto the Oxc formatter (oxfmt), replacing **both** prettier (editor) and dprint (treefmt/pre-commit).

## treefmt (pre-commit)
- `programs.oxfmt` enabled with its **full default include set**: JS/TS/JSX/TSX, JSON/JSONC/JSON5, CSS/SCSS, HTML, Markdown/MDX, YAML, GraphQL, Vue.
- **dprint removed entirely** (it previously owned md/json/yaml/html — all now handled by oxfmt). Also dropped from the dev shell.
- Untouched: `nixfmt` (nix), `shfmt` (shell), `stylua` (lua), `kdlfmt` (kdl) — oxfmt doesn't cover those, no overlap.

## Editor
- `config/vscode/settings.json` + `config/cursor/settings.json`: default formatter `esbenp.prettier-vscode` → `oxc.oxc-vscode`.
- `.vscode/extensions.json`: recommend `oxc.oxc-vscode` instead of `esbenp.prettier-vscode`.
- `bodil.prettier-toml` left as-is (oxfmt has no TOML support).

## Verification
- Confirmed oxfmt correctly formats **every** type dprint previously owned (md, json, yaml, html) plus jsonc/json5/css/scss/graphql/vue/mdx — tested each with deliberately mis-formatted samples.
- `nix fmt` rebuilds treefmt (dprint gone) and is idempotent (second run: 0 changed). Repo-wide reformat churn is minimal: only two settings files (oxfmt inlines a short `eslint.validate` array); existing md/yaml/html were already oxfmt-clean.