### PR TITLE
dev: add .gtrconfig to run direnv allow on new worktrees

### DIFF
--- a/.gtrconfig
+++ b/.gtrconfig
@@ -1,0 +1,9 @@
+# .gtrconfig - Repository-level git-worktree-runner configuration
+# gitconfig syntax, parsed natively by git. Committed to the repo.
+# Docs: https://github.com/coderabbitai/git-worktree-runner
+
+[hooks]
+    # Run after creating a worktree. The hook runs in the new worktree
+    # directory, so `direnv allow` trusts that worktree's .envrc.
+    # Env available: REPO_ROOT, WORKTREE_PATH, BRANCH
+    postCreate = direnv allow


### PR DESCRIPTION
## Summary
- Add `.gtrconfig` with a `postCreate` hook that runs `direnv allow` in newly created `gtr` worktrees, so each worktree's `.envrc` is trusted automatically.

## Notes
- The hook runs in the worktree directory, so plain `direnv allow` targets the new worktree's `.envrc`.
- `gtr` requires per-machine approval of committed `.gtrconfig` hooks; run `git gtr trust` once after cloning on a new machine.