### PR TITLE
ci: add free static-analysis scanners and AI-reviewer configs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit is free for public/open-source repositories.
+# Install the app once at https://github.com/apps/coderabbitai
+language: en-US
+early_access: false
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - master
+  path_filters:
+    # Skip Nix build output and the generated lockfile — no signal there.
+    - "!result*/**"
+    - "!flake.lock"
+chat:
+  auto_reply: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "27 5 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # This repo is Nix + shell with no JS/TS to scan; CodeQL does support
+        # scanning GitHub Actions workflows, which this repo does have.
+        language: [actions]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          languages: ${{ matrix.language }}
+          # Actions/JS/TS need no compiler; skip the autobuild step entirely.
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "27 5 * * 1"
 
+# Keep only the latest run per branch; cancel superseded runs on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -24,10 +24,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Full history is only needed for the weekly schedule, which sweeps
-          # the entire repo. On push/PR gitleaks scans just the new commits, so
-          # a shallow checkout keeps those runs cheap as history grows.
-          fetch-depth: ${{ github.event_name == 'schedule' && '0' || '1' }}
+          # gitleaks-action diffs the full base..head commit range (and the
+          # weekly schedule sweeps the entire repo), so it needs every commit
+          # in that range present. A shallow checkout omits the base commit and
+          # makes the scan fail with "unknown revision", so fetch full history.
+          fetch-depth: 0
           persist-credentials: false
 
       # Gitleaks is free for public repositories — no GITLEAKS_LICENSE needed.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,40 @@
+name: Gitleaks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "42 5 * * 1"
+
+jobs:
+  scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Gitleaks is free for public repositories — no GITLEAKS_LICENSE needed.
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The action always writes results.sarif to the workspace; we publish
+          # it to code scanning below, so skip the redundant workflow artifact.
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+
+      # if: always() so a finding (which fails the step above) still publishes
+      # the report to code scanning before the job is marked failed.
+      - name: Upload SARIF to GitHub code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "42 5 * * 1"
 
+# Keep only the latest run per branch; cancel superseded runs on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     name: Secret scan
@@ -19,7 +24,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          # Full history is only needed for the weekly schedule, which sweeps
+          # the entire repo. On push/PR gitleaks scans just the new commits, so
+          # a shallow checkout keeps those runs cheap as history grows.
+          fetch-depth: ${{ github.event_name == 'schedule' && '0' || '1' }}
           persist-credentials: false
 
       # Gitleaks is free for public repositories — no GITLEAKS_LICENSE needed.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "19 6 * * 2"
+  push:
+    branches: [master]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,9 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      # Job-level permissions fully replace the workflow-level read-all, so
+      # contents: read must be restated here or actions/checkout 403s.
+      contents: read
       security-events: write
       id-token: write
 
@@ -35,7 +38,10 @@ jobs:
           results_format: sarif
           publish_results: true
 
+      # if: always() so a failed analysis step still publishes whatever SARIF
+      # was produced, matching the other scanner workflows.
       - name: Upload SARIF to GitHub code scanning
+        if: always()
         uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches: [master]
 
+# Keep only the latest run per branch; cancel superseded runs on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,50 @@
+name: Semgrep
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "31 5 * * 1"
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Semgrep
+        run: pip install semgrep==1.170.0
+
+      # No SEMGREP_APP_TOKEN needed — these registry rulesets are free.
+      # Semgrep exits 0 on findings by default (no --error), so a non-zero exit
+      # means a genuine scan/config failure and should fail the job — hence no
+      # continue-on-error here. The upload step below uses if: always() so the
+      # SARIF is still published even when the scan fails.
+      - name: Run Semgrep
+        run: >
+          semgrep scan
+          --config p/default
+          --config p/security-audit
+          --config p/secrets
+          --sarif --output semgrep.sarif
+
+      - name: Upload SARIF to GitHub code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "31 5 * * 1"
 
+# Keep only the latest run per branch; cancel superseded runs on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   semgrep:
     name: Scan

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,37 @@
+name: Trivy
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "51 5 * * 1"
+
+jobs:
+  scan:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload SARIF to GitHub code scanning
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "51 5 * * 1"
 
+# Keep only the latest run per branch; cancel superseded runs on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     name: Vulnerability scan

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -36,7 +36,10 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
 
+      # if: always() so a failed scan still publishes whatever SARIF was
+      # produced, matching the other scanner workflows.
       - name: Upload SARIF to GitHub code scanning
+        if: always()
         uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26 # v3.37.1
         with:
           sarif_file: trivy-results.sarif

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -15,7 +15,9 @@ github:
 
 # Sourcery does not support recursive `**` globs; use directory paths and
 # single-level wildcards. This repo is Nix + shell; skip the generated
-# lockfile and any Nix build output symlinks.
+# lockfile and any Nix build output symlinks (`result`, plus `result-1`,
+# `result-2`, … that `nix build` emits for multiple outputs).
 ignore:
   - flake.lock
   - result
+  - result-*

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,21 @@
+# Sourcery is free for public/open-source repositories.
+# Install the app once at https://github.com/apps/sourcery-ai
+rule_settings:
+  enable:
+    - default
+  rule_types:
+    - refactoring
+    - suggestion
+    - comment
+
+github:
+  review_comments: true
+  request_review: author
+  sourcery_branch: sourcery/{base_branch}
+
+# Sourcery does not support recursive `**` globs; use directory paths and
+# single-level wildcards. This repo is Nix + shell; skip the generated
+# lockfile and any Nix build output symlinks.
+ignore:
+  - flake.lock
+  - result


### PR DESCRIPTION
Ported from [macalinao/temporal-utils#71](https://github.com/macalinao/temporal-utils/pull/71) (itself from grill#161). Adds five free, language-agnostic static-analysis workflows plus two AI-reviewer configs. New files only — `.github/workflows/check.yml` and `.github/dependabot.yml` are untouched.

## Workflows added

| File | What it does |
|------|--------------|
| `.github/workflows/codeql.yml` | GitHub CodeQL. Adapted `language` to `actions` (see below). Weekly cron, PR + push on `master`, SARIF → code scanning. |
| `.github/workflows/semgrep.yml` | Semgrep registry rulesets `p/default`, `p/security-audit`, `p/secrets`. Weekly cron, SARIF upload. |
| `.github/workflows/trivy.yml` | Trivy filesystem vuln scan (`CRITICAL,HIGH`), SARIF upload. |
| `.github/workflows/gitleaks.yml` | Secret scanning over full history, SARIF upload. |
| `.github/workflows/scorecard.yml` | OSSF Scorecard supply-chain posture, SARIF upload + published results. |

All keep `persist-credentials: false`, weekly `schedule` crons, `branches: [master]`, and SARIF upload to GitHub code scanning.

## AI-reviewer configs

- `.coderabbit.yaml` — CodeRabbit (free for OSS). `chill` profile, auto-review on `master`.
- `.sourcery.yaml` — Sourcery (free for OSS). Default rules, author review.

## Action pins — all refreshed to latest release

Every `uses:` is SHA-pinned to the tag's commit:

| Action | Tag | SHA (short) |
|--------|-----|-------------|
| `actions/checkout` | v7.0.0 | `9c091bb` |
| `github/codeql-action` (init/analyze/upload-sarif) | v3.37.1 | `b7351df` |
| `actions/setup-python` | v7.0.0 | `5fda3b9` |
| `gitleaks/gitleaks-action` | v3.0.0 | `e0c47f4` |
| `ossf/scorecard-action` | v2.4.3 | `4eaacf0` |
| `aquasecurity/trivy-action` | v0.36.0 | `ed142fd` |

Notes on version bumps vs. the temporal-utils original:
- checkout `v6 → v7.0.0`, setup-python `v5 → v7.0.0`, scorecard `v2.4.0 → v2.4.3`.
- gitleaks-action `v2 → v3.0.0` — v3 is a clean Node 20 → 24 runtime bump with no input/output/behavior changes (v2 stops working once GitHub removes Node 20 in Sep 2026).
- codeql-action `v3` moving tag now resolves to `v3.37.1` (kept on v3 line; v4 exists but v3 is current and supported).
- trivy-action stays at v0.36.0 (already the latest release).
- Semgrep pip pin stays at `semgrep==1.170.0` — confirmed the current latest on PyPI.

## Adaptations for this Nix/shell repo

temporal-utils is a `packages/*` TypeScript monorepo; this repo is Nix + shell (`nix/`, `scripts/`, `config/`) with **zero** JS/TS files (`git ls-files '*.ts' '*.js' … ` → 0). Changes vs. the original:

- **CodeQL**: switched `languages` from `javascript-typescript` to `actions`. There is no JS/TS to scan (which would fail the job with "no source found"), but the repo does have GitHub Actions workflows, which CodeQL can scan. This keeps the workflow meaningful and green. CodeQL does not support Nix, so no Nix language was invented.
- **Semgrep**: dropped the `p/typescript` ruleset (no TS here); kept `p/default`, `p/security-audit`, `p/secrets`.
- **`.coderabbit.yaml`**: replaced the TS-oriented `!**/dist/**` path filter with `!result*/**` and `!flake.lock` (Nix build output is `result*` symlinks; the lockfile is generated). Dropped the `oxlint` tool block (no JS/TS).
- **`.sourcery.yaml`**: replaced the `packages/*/dist/` ignore with `flake.lock` + `result`.

Trivy, Gitleaks, and OSSF Scorecard are language-agnostic and kept essentially as-is.

## Summary by Sourcery

Add security-focused static analysis and AI-review automation for this repository.

New Features:
- Introduce Semgrep workflow to run multiple registry rulesets and upload SARIF results to GitHub code scanning.
- Add CodeQL workflow configured to analyze GitHub Actions in this repository.
- Add Gitleaks workflow to scan the full git history for secrets and publish code scanning results.
- Add Trivy filesystem workflow to detect high and critical vulnerabilities and report via SARIF.
- Add OSSF Scorecard workflow to assess repository supply-chain security posture and publish results.
- Add CodeRabbit configuration to automatically review pull requests to the master branch.
- Add Sourcery configuration to provide automated refactoring and review suggestions with repository-appropriate ignores.

CI:
- Configure multiple scheduled and PR/push-triggered security scanning workflows (Semgrep, CodeQL, Gitleaks, Trivy, OSSF Scorecard) with pinned GitHub Actions SHAs.
- Integrate CodeRabbit and Sourcery GitHub Apps via repository-level config for automated AI-assisted code review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added automated security and quality scanning via CodeQL, secret scanning, Semgrep, Trivy (filesystem), and OSSF Scorecard on pushes, pull requests, and scheduled runs.
  * Publishes SARIF results to the project’s code-scanning interface to streamline review.

* **Pull Request Experience**
  * Improved automated pull request review behavior for drafts and non-drafts with updated review and path filtering settings.

* **Chores**
  * Added/updated tooling configuration for automated analysis and review workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->