### PR TITLE
ci: drop macos-15-intel from check matrix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         runsOn:
           - ubuntu-22.04
-          - macos-15-intel # check things work on Intel
           - macos-26
     runs-on: ${{ matrix.runsOn }}
     steps:


### PR DESCRIPTION
Removes the `macos-15-intel` runner entry from the `check` job's build matrix in `.github/workflows/check.yml`. It was the only occurrence of the string in the repo.

`nix flake check` still runs on `ubuntu-22.04` and `macos-26`. General `x86_64-darwin` Nix host support (e.g. `ian-mbp-intel`, `ci-personal`) is untouched — those aren't tied to this runner label.

## Summary by Sourcery

CI:
- Update the check workflow matrix to run only on ubuntu-22.04 and macOS-26 runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS validation to run on a newer runner.
  * Removed the deprecated Intel macOS runner from automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->